### PR TITLE
Add command-line tool for prayer text reformatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,69 @@
 # prayer-text-reformatter
+
+A small utility for converting prayer request snippets into the bullet-point format shown in the example below. It ships with a simple command-line interface and can be bundled into an offline executable with tools such as [PyInstaller](https://pyinstaller.org/).
+
+## Example
+
+**Input**
+
+```
+Nov 16, 2024: Nepal – Caste Discrimination and the Church
+
+In Nepal, the caste system has long created division, excluding many from opportunities and causing discrimination and injustice. As the church grows, it has the opportunity to be a powerful witness of unity, breaking down caste barriers and showing that in Christ, all are equally valued and loved. Still some who are in Christ have not accepted this revelation of oneness.
+
+Pray for the church in Nepal to be a place where caste barriers are broken, demonstrating the equal value of all people in Christ.
+
+Ask for believers to lead by example, promoting love and inclusion in their communities.
+
+Pray for those who have suffered under caste discrimination to find acceptance, healing, and hope within the body of Christ.
+```
+
+**Output**
+
+```
+*Nov 16, 2024 | Nepal – Caste Discrimination and the Church*
+
+In Nepal, the caste system has long created division, excluding many from opportunities and causing discrimination and injustice. As the church grows, it has the opportunity to be a powerful witness of unity, breaking down caste barriers and showing that in Christ, all are equally valued and loved. Still some who are in Christ have not accepted this revelation of oneness.
+
+- Pray for the church in Nepal to be a place where caste barriers are broken, demonstrating the equal value of all people in Christ.
+
+- Ask for believers to lead by example, promoting love and inclusion in their communities.
+
+- Pray for those who have suffered under caste discrimination to find acceptance, healing, and hope within the body of Christ.
+```
+
+## Installation
+
+```bash
+python -m pip install .
+```
+
+This command installs the `prayer-text-reformatter` package and exposes the `prayer-text-reformatter` CLI.
+
+## Usage
+
+```bash
+prayer-text-reformatter input.txt output.txt
+```
+
+If the output file is omitted the reformatted text is written to standard output.
+
+## Creating an offline executable
+
+You can use PyInstaller to create a single-file executable (on Windows, macOS, or Linux) that runs without Python being installed.
+
+```bash
+python -m pip install pyinstaller
+pyinstaller -F -n prayer-text-reformatter src/prayer_text_reformatter/cli.py
+```
+
+The resulting executable will be available in the `dist/` directory.
+
+## Development
+
+Install the project in editable mode and run the tests:
+
+```bash
+python -m pip install -e .
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "prayer-text-reformatter"
+version = "0.1.0"
+description = "CLI for reformatting prayer text into bullet point format"
+readme = "README.md"
+authors = [{name = "Prayer Text Reformatter"}]
+requires-python = ">=3.9"
+
+[project.scripts]
+prayer-text-reformatter = "prayer_text_reformatter.cli:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]

--- a/src/prayer_text_reformatter/__init__.py
+++ b/src/prayer_text_reformatter/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for reformatting prayer text snippets."""
+
+from .formatter import reformat_prayer_text
+
+__all__ = ["reformat_prayer_text"]

--- a/src/prayer_text_reformatter/cli.py
+++ b/src/prayer_text_reformatter/cli.py
@@ -1,0 +1,50 @@
+"""Command line interface for the prayer text reformatter."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import sys
+
+from .formatter import reformat_prayer_text
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert prayer request text into the bullet-point format used by "
+            "the prayer-text-reformatter project."
+        )
+    )
+    parser.add_argument(
+        "input",
+        type=Path,
+        help="Path to the plain-text file to be reformatted.",
+    )
+    parser.add_argument(
+        "output",
+        type=Path,
+        nargs="?",
+        help=(
+            "Optional path for the reformatted text. If omitted, the result is "
+            "printed to standard output."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    raw_text = args.input.read_text(encoding="utf-8")
+    formatted = reformat_prayer_text(raw_text)
+
+    if args.output:
+        args.output.write_text(formatted + "\n", encoding="utf-8")
+    else:
+        sys.stdout.write(formatted + "\n")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/src/prayer_text_reformatter/formatter.py
+++ b/src/prayer_text_reformatter/formatter.py
@@ -1,0 +1,85 @@
+"""Core text formatting logic for prayer entries."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def reformat_prayer_text(text: str) -> str:
+    """Return a reformatted version of *text* following the specified layout.
+
+    The expected input format is a header line containing a date followed by a
+    colon, the location/title segment, and any number of paragraphs separated by
+    blank lines. The first paragraph remains unbulleted, while subsequent
+    paragraphs are turned into bulleted lines that are separated by blank lines.
+    """
+
+    lines = _normalize_newlines(text).split("\n")
+    header, remainder = _extract_header(lines)
+    paragraphs = _collect_paragraphs(remainder)
+    if not paragraphs:
+        return header
+
+    body = []
+    body.append(paragraphs[0])
+
+    for paragraph in paragraphs[1:]:
+        body.append(f"- {paragraph}")
+
+    return "\n\n".join([header, *body])
+
+
+def _normalize_newlines(text: str) -> str:
+    """Normalize CRLF line endings to LF to simplify processing."""
+
+    return text.replace("\r\n", "\n").replace("\r", "\n").strip()
+
+
+def _extract_header(lines: Iterable[str]) -> tuple[str, list[str]]:
+    """Return the formatted header and the remaining lines to process."""
+
+    iterator = iter(lines)
+    for raw_line in iterator:
+        line = raw_line.strip()
+        if not line:
+            continue
+        formatted_header = _format_header(line)
+        remainder = list(iterator)
+        return formatted_header, remainder
+    raise ValueError("The provided text does not contain a header line.")
+
+
+def _format_header(line: str) -> str:
+    """Format the header line into italic text with a vertical bar separator."""
+
+    if ":" not in line:
+        raise ValueError(
+            "Header line must contain a colon separating date and location/title."
+        )
+    first, rest = line.split(":", 1)
+    return f"*{first.strip()} | {rest.strip()}*"
+
+
+def _collect_paragraphs(lines: Iterable[str]) -> list[str]:
+    """Group the remaining lines into paragraphs separated by blank lines."""
+
+    paragraphs: list[str] = []
+    current: list[str] = []
+
+    def flush_current() -> None:
+        if current:
+            paragraphs.append(" ".join(current).strip())
+            current.clear()
+
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line:
+            flush_current()
+            continue
+        current.append(line)
+
+    flush_current()
+    return paragraphs
+
+
+__all__ = ["reformat_prayer_text"]

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,31 @@
+from prayer_text_reformatter import reformat_prayer_text
+
+
+def test_reformat_example_text():
+    raw = (
+        "Nov 16, 2024: Nepal – Caste Discrimination and the Church\n\n"
+        "In Nepal, the caste system has long created division, excluding many from opportunities and causing discrimination and injustice. As the church grows, it has the opportunity to be a powerful witness of unity, breaking down caste barriers and showing that in Christ, all are equally valued and loved. Still some who are in Christ have not accepted this revelation of oneness.\n\n"
+        "Pray for the church in Nepal to be a place where caste barriers are broken, demonstrating the equal value of all people in Christ.\n\n"
+        "Ask for believers to lead by example, promoting love and inclusion in their communities.\n\n"
+        "Pray for those who have suffered under caste discrimination to find acceptance, healing, and hope within the body of Christ.\n"
+    )
+
+    expected = (
+        "*Nov 16, 2024 | Nepal – Caste Discrimination and the Church*\n\n"
+        "In Nepal, the caste system has long created division, excluding many from opportunities and causing discrimination and injustice. As the church grows, it has the opportunity to be a powerful witness of unity, breaking down caste barriers and showing that in Christ, all are equally valued and loved. Still some who are in Christ have not accepted this revelation of oneness.\n\n"
+        "- Pray for the church in Nepal to be a place where caste barriers are broken, demonstrating the equal value of all people in Christ.\n\n"
+        "- Ask for believers to lead by example, promoting love and inclusion in their communities.\n\n"
+        "- Pray for those who have suffered under caste discrimination to find acceptance, healing, and hope within the body of Christ."
+    )
+
+    assert reformat_prayer_text(raw) == expected
+
+
+def test_missing_header_raises_value_error():
+    raw = "\n\nNo header here."
+    try:
+        reformat_prayer_text(raw)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected ValueError when header is missing")


### PR DESCRIPTION
## Summary
- add formatter module and CLI that converts prayer request text into the bullet-point layout
- package the project with setuptools and document installation plus PyInstaller usage
- add pytest coverage for the formatter behaviour and error handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da568ab9b88324ad2a08adb98538be